### PR TITLE
CARD_ORDER_CHECKOUT in TransactionDetailsType hinzugefügt.

### DIFF
--- a/src/de/willuhn/jameica/hbci/transferwise/domain/accountstatements/TransactionDetailsType.java
+++ b/src/de/willuhn/jameica/hbci/transferwise/domain/accountstatements/TransactionDetailsType.java
@@ -29,6 +29,11 @@ public enum TransactionDetailsType
   CARD,
   
   /**
+   * Bestellung einer neuen Karte
+   */
+  CARD_ORDER_CHECKOUT,
+  
+  /**
    * Waehrungswechsel.
    */
   CONVERSION,


### PR DESCRIPTION
Ich bin bei Benutzung des Plugins in ein Problem gelaufen:

```
[07.02.2024 11:19:59] Synchronization via Transferwise in progress
[07.02.2024 11:19:59]  
[07.02.2024 11:19:59] Synchronizing Account: IBAN <redacted> [BIC: <redacted>]
[07.02.2024 11:19:59] Führe Geschäftsvorfall aus: "IBAN <redacted> [BIC: <redacted>]:Get Transactions/Balance"
[07.02.2024 11:20:00] Fehler beim Erstellen der Abfrage: Cannot deserialize value of type `de.willuhn.jameica.hbci.transferwise.domain.accountstatements.TransactionDetailsType` from String "CARD_ORDER_CHECKOUT": not one of the values accepted for Enum class: [CARD, MONEY_ADDED, ACCRUAL_CHARGE, DIRECT_DEBIT, OUTGOING_CROSS_BALANCE, TRANSFER, DEPOSIT, INCOMING_CROSS_BALANCE, CONVERSION, UNKNOWN]
 at [Source: (StringReader); line: 1, column: 146892] (through reference chain: de.willuhn.jameica.hbci.transferwise.domain.accountstatements.AccountStatement["transactions"]->java.util.ArrayList[192]->de.willuhn.jameica.hbci.transferwise.domain.accountstatements.Transaction["details"]->de.willuhn.jameica.hbci.transferwise.domain.accountstatements.TransactionDetails["type"])
```

Ich würde mal davon ausgehen, dass das Problem mit meinem Change gefixed ist, bin mir aber nicht 100% sicher wie das alles genau funktioniert, und weiß erst recht nicht wie ich das in meiner bestehenden Hibiscus Installation sinnvoll testen könnte.
